### PR TITLE
Spark: spark 3.2.2 version bump

### DIFF
--- a/spark/v3.2/build.gradle
+++ b/spark/v3.2/build.gradle
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-String sparkVersion = '3.2.1'
+String sparkVersion = '3.2.2'
 String sparkMajorVersion = '3.2'
 String scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
 


### PR DESCRIPTION
upgrade spark to 3.2.2 

To download Spark 3.2.2, head over to the download page:
https://spark.apache.org/downloads.html

To view the release notes:
https://spark.apache.org/releases/spark-release-3-2-2.html